### PR TITLE
 Add leading zero to minutes, make deployment easier (ignore configuration.js)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+configuration.js
 data/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dashiell
 
-An IRC bot that displays data from [strava](http://www.strava.com).
+An IRC bot that displays data from [Strava](http://www.strava.com).
 
 ## Installation
 
@@ -8,6 +8,7 @@ An IRC bot that displays data from [strava](http://www.strava.com).
 * `$ mkdir data`
 * `$ cp node_modules/strava-v3/strava_config data/strava_config`
 * Open `data/strava_config` and supply your application's `access_token` to the `access_token` field.
+* `$ cp configuration.js-dist configuration.js`
 * Open `configuration.js` and supply your settings.
 
 ## Usage

--- a/bot.js
+++ b/bot.js
@@ -3,6 +3,7 @@ var strava = require('strava-v3');
 var strftime = require('strftime');
 var util = require('util');
 var settings = require('./configuration.js');
+var sprintf = require("sprintf-js").sprintf;
 
 var leaderboardMetrics = new Array('achievements', 'activities', 'distance', 'elevation');
 var help = {'help' : 'Show this help text',
@@ -18,7 +19,7 @@ var client = new irc.Client(settings.host, settings.nickname, {
   port: settings.port,
   channels: settings.channels
 });
-util.log('connected to IRC')
+util.log('connected to IRC');
 
 client.addListener('message', function(from, to, message) {
   util.log(from + ' => ' + to + ': "' + message + '"');
@@ -54,7 +55,7 @@ client.addListener('message', function(from, to, message) {
           util.log('club: ' + util.inspect(club));
           strava.clubs.listActivities({'id': settings.club, 'per_page': 200}, function(err, activities) {
             buildLeaderboard(activities, command.split(' ')[1]);
-          })
+          });
         });
         break;
       case 'source':
@@ -66,7 +67,7 @@ client.addListener('message', function(from, to, message) {
     return;
   }
 
-  var activitySearch = new RegExp('activit(ies\/|y\\s+)(\\d+)')
+  var activitySearch = new RegExp('activit(ies\/|y\\s+)(\\d+)');
   if (message.search(activitySearch) !== -1) {
     var activityID = message.match(activitySearch)[2];
     util.log('activity ' + activityID + ' mentioned');
@@ -78,17 +79,17 @@ client.addListener('message', function(from, to, message) {
   function calculatePace(meters, seconds) {
     var secondsPerKm = seconds / (meters / 1000);
     var minutesPerKm = Math.floor(secondsPerKm / 60);
-    var pacePerKm = util.format('%s:%s', minutesPerKm, Math.round(secondsPerKm - minutesPerKm * 60));
+    var pacePerKm = sprintf('%d:%02d', minutesPerKm, Math.round(secondsPerKm - minutesPerKm * 60));
     var secondsPerMile = secondsPerKm / 0.621371192;
     var minutesPerMile = Math.floor(secondsPerMile / 60);
-    var pacePerMile = util.format('%s:%s', minutesPerMile, Math.round(secondsPerMile - minutesPerMile * 60));
+    var pacePerMile = sprintf('%d:%02d', minutesPerMile, Math.round(secondsPerMile - minutesPerMile * 60));
     return util.format('%s/km (%s/mi)', pacePerKm, pacePerMile);
   }
 
   function calculateDistance(meters) {
     kilometers = meters / 1000;
     miles = kilometers * 0.621371192;
-    return util.format('%skm (%smi)', Math.round(kilometers * 10) / 10, Math.round(miles * 10) / 10);
+    return util.format('%s km (%s mi)', Math.round(kilometers * 10) / 10, Math.round(miles * 10) / 10);
   }
 
   function buildLeaderboard(activities, metric) {
@@ -134,7 +135,7 @@ client.addListener('message', function(from, to, message) {
     for (var athlete in metrics) {
       sortedMetrics.push([athlete, metrics[athlete]]);
     }
-    sortedMetrics.sort(function(a, b) { return b[1] - a[1] });
+    sortedMetrics.sort(function(a, b) { return b[1] - a[1]; });
 
     client.say(respondTo, util.format('\00307(leaderboard)\017 for \002%s\002 in the last %s days:', description, settings.leaderboardDays));
     sortedMetrics.slice(0, 5).forEach(function(distance, i) {

--- a/configuration.js-dist
+++ b/configuration.js-dist
@@ -6,4 +6,4 @@ module.exports = {
   club: 0,
   leaderboardDays: 7,
   leaderboardMaxSize: 5
-}
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "irc": ">= 0.3.7",
+    "sprintf-js": ">= 1.0.2",
     "strava-v3": ">= 1.5.2",
     "strftime": ">=0.8.2"
   }


### PR DESCRIPTION
util.format can't add leading zero, using sprintf-js instead.
Also fixed some linter warnings.
